### PR TITLE
feature/5-6-version-interpretation-select into develop

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,8 +5,8 @@ init-hook='''
         import os, sys;
         sys.path.append(os.path.dirname(find_pylintrc()));
         '''
-max-args=10
-max-locals=20
+max-args=15
+max-locals=25
 fail-on=
         useless-suppression,
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,11 +70,23 @@ Compare to [stable](https://github.com/VoltServer/UL1400-1_analyzer/compare/stab
 - [Added] `.mypy.ini` added to configure `mypy` execution for app code and test
       code ([#1][]).
 - [Added] `max-locals` set to `20` ([#4][]).
+- [Changed] `max-locals` increased from `20` to `25` to balance out the
+      `max-args` being increased from `10` to `15` ([#5][], [#6][]).
+
+
+### Analysis: Analyzer Support
+- [Added] `analyzer_support.py` added for shared data and functionality among
+      analyzers, which for now is `Interpretation` and `StandardVersion` enums
+      with defaults defined ([#5][], [#6][]).
 
 
 ### Analysis: Letgo Analyzer
 - [Added] `letgo_analyzer.py` added with ability to analyze waveforms strictly
       to UL1400-1 with parallel CPU core processing support ([#4][]).
+- [Added] Audit function added to check if the configuration used is critically
+      valid for UL1400-1 assessment ([#5][], [#6][]).
+- [Changed] Current and voltage let-go assessments now performed with the
+      interpretation level and standard version factored in ([#5][], [#6][]).
 
 
 ### Data Import: Data Importer
@@ -91,6 +103,11 @@ Compare to [stable](https://github.com/VoltServer/UL1400-1_analyzer/compare/stab
       in CLI help messages ([#4][]).
 
 
+## Utils: CLI:
+- [Added] `cli.py` added for CLI processing support, with case-insensitive enum
+      option parsing implemented ([#5][], [#6][]).
+
+
 ## Utils: Waveform
 - [Added] `waveform.py` added to encapsulate generic waveform manipulations,
       such as extracting segments and merging regions ([#4][]).
@@ -99,6 +116,8 @@ Compare to [stable](https://github.com/VoltServer/UL1400-1_analyzer/compare/stab
 ### Main
 - [Added] `main.py` added with CLI sub-parser for letgo and help function to
       route CLI args to letgo analyzer as well as display results ([#4][]).
+- [Added] Support for interpretation level and standard version CLI args added
+      along with the usage and audit for those parameters ([#5][], [#6][]).
 
 
 ### Version
@@ -115,7 +134,9 @@ Compare to [stable](https://github.com/VoltServer/UL1400-1_analyzer/compare/stab
 ### Docs: CONTRIBUTING
 - [Added] `CONTRIBUTING.md` added to project root, covering dev setup, general
       workflow, and conventions ([#1][]).
-
+- [Added] Added convention that exceptions will be raised if an unsupported
+      interpretation or standard version encountered in a function that uses
+      that configuration ([#5][], [#6][]).
 
 ### Docs: README
 - [Changed] Updated with project intro (mostly placeholder), links, CI badge
@@ -138,12 +159,15 @@ Compare to [stable](https://github.com/VoltServer/UL1400-1_analyzer/compare/stab
 #### Issues
 - [#1][]
 - [#4][]
+- [#5][]
+- [#6][]
 - [#7][]
 
 #### PRs
 - [#2][] for [#1][]
 - [#8][] for [#7][]
 - [#9][] for [#4][]
+- [#10][] for [#5][], [#6][]
 
 ---
 
@@ -153,7 +177,10 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#1]: https://github.com/VoltServer/UL1400-1_analyzer/issues/1 'Issue #1'
 [#7]: https://github.com/VoltServer/UL1400-1_analyzer/issues/7 'Issue #7'
 [#4]: https://github.com/VoltServer/UL1400-1_analyzer/issues/4 'Issue #4'
+[#5]: https://github.com/VoltServer/UL1400-1_analyzer/issues/5 'Issue #5'
+[#6]: https://github.com/VoltServer/UL1400-1_analyzer/issues/6 'Issue #6'
 
 [#2]: https://github.com/VoltServer/UL1400-1_analyzer/pull/2 'PR #2'
 [#8]: https://github.com/VoltServer/UL1400-1_analyzer/pull/8 'PR #8'
 [#9]: https://github.com/VoltServer/UL1400-1_analyzer/pull/9 'PR #9'
+[#10]: https://github.com/VoltServer/UL1400-1_analyzer/pull/10 'PR #10'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,14 @@ development, it is most likely that `dev-required` is the correct arg.
 
 # Conventions
 
+## Interpretation and Standard Version Support
+In some parts of this project, different decisions are made depending on which
+version of the standard is being used as well as the interpretation level that
+is allowed.  Any function that acts on either of these parameters MUST include
+a check that raises an exception if any option other than those supported at the
+time of development is provided.
+
+
 ## Logger
 Balancing readability against performance, the pylint warnings
 `logging-fstring-interpolation` and `logging-not-lazy` are disabled.  The

--- a/ul1400_1_analyzer/analysis/__init__.py
+++ b/ul1400_1_analyzer/analysis/__init__.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
+    'analyzer_support',
     'letgo_analyzer',
 ]

--- a/ul1400_1_analyzer/analysis/analyzer_support.py
+++ b/ul1400_1_analyzer/analysis/analyzer_support.py
@@ -3,5 +3,52 @@ This encapsulates any generic supporting elements that may be required by more
 than 1 analyzer module.
 
 Module Attributes:
-  N/A
+  DEFAULT_INTERPRETATION: The default interpretation level to be used by this
+    project.
+  DEFAULT_STANDARD_VERSION: The default version of the standard to be used by
+    this project.
+  LATEST_STANDARD_VERSION: The latest released version of the standard.
 """
+from __future__ import annotations
+from enum import Enum
+
+
+
+class Interpretation(Enum):
+    """
+    These are the "levels" of how the standard should be interpreted, ranging
+    from a strict adherence to everything exactly as it is written to
+    speculative attempts to resolve ambiguous, conflicting, or absent material.
+    Higher levels should be used with increased caution, as they are at greater
+    risk of not being the official final interpretation per the standards body.
+    """
+    STRICT = 'Level 0: This only allows interpretations strictly adhering to' \
+            ' the exact language in the standard.'
+    TYPOS = 'Level 1: This allows provable typos in the standard to be fixed' \
+            ' and used in the analysis.'
+    REASONABLE = 'Level 2: This allows ambiguous, conflicting, or absent' \
+            ' material from the standard to be resolved where a reasonably' \
+            ' confident interpretation is possible.  This should be something' \
+            ' where arguments can be constructed based on other parts of the' \
+            ' the standard or the referenced literature.  This also' \
+            ' incorporates previous levels where possible.'
+    SPECULATIVE = 'Level 3: This allows for experimental and other wildly' \
+            ' speculative interpretations to be explored as solutions to' \
+            ' ambiguous, conflicting, or absent material that cannot' \
+            ' otherwise be proven with reasonable confidence.  This also' \
+            ' incorporates previous levels where possible.'
+
+
+
+class StandardVersion(Enum):
+    """
+    The supported versions of the standard that can be analyzed against.
+    """
+    UL1400_1_ISSUE_1 = 'UL1400-1, Issue Number 1; December 19, 2022'
+
+
+
+DEFAULT_INTERPRETATION = Interpretation.STRICT
+
+LATEST_STANDARD_VERSION = StandardVersion.UL1400_1_ISSUE_1
+DEFAULT_STANDARD_VERSION = LATEST_STANDARD_VERSION

--- a/ul1400_1_analyzer/analysis/analyzer_support.py
+++ b/ul1400_1_analyzer/analysis/analyzer_support.py
@@ -1,0 +1,7 @@
+"""
+This encapsulates any generic supporting elements that may be required by more
+than 1 analyzer module.
+
+Module Attributes:
+  N/A
+"""

--- a/ul1400_1_analyzer/analysis/letgo_analyzer.py
+++ b/ul1400_1_analyzer/analysis/letgo_analyzer.py
@@ -340,7 +340,8 @@ def is_current_below_letgo(segment_values:list[float]|None,
 
     Raise:
       ValueError: Raised if an ambiguous condition with respect to UL1400-1 is
-        encountered and could not be resolved.
+        encountered and could not be resolved; or if an unsupported
+        interpretation or standard version was provided.
     """
     if segment_values is None:
         return None
@@ -401,6 +402,7 @@ def is_voltage_below_letgo(segment_values:list[float]|None,
         interpretation:Interpretation=analyzer_support.DEFAULT_INTERPRETATION,
         standard_version:StandardVersion=
             analyzer_support.DEFAULT_STANDARD_VERSION) -> bool|None:
+    # pylint: disable=too-many-branches
     """
     Determines if the provided segment of data is below the let-go threshold for
     voltage.  When the appropriate data is provided, this can be used to assess
@@ -428,7 +430,8 @@ def is_voltage_below_letgo(segment_values:list[float]|None,
     Raise:
       ValueError: Raised if an ambiguous condition with respect to UL1400-1 is
         encountered and could not be resolved; or if an invalid value for the
-        environmental condition is provided.
+        environmental condition is provided; or if an unsupported interpretation
+        or standard version was provided.
     """
     if segment_values is None:
         return None

--- a/ul1400_1_analyzer/analysis/letgo_analyzer.py
+++ b/ul1400_1_analyzer/analysis/letgo_analyzer.py
@@ -14,6 +14,9 @@ from typing import Any
 
 from alive_progress import alive_bar                      # type: ignore[import]
 
+from ul1400_1_analyzer.analysis import analyzer_support
+from ul1400_1_analyzer.analysis.analyzer_support \
+        import Interpretation, StandardVersion
 from ul1400_1_analyzer.utils import waveform as waveform_utils
 
 
@@ -42,7 +45,10 @@ def _init_shared_data(shared_data:Any) -> None:
 def find_time_regions_below_letgo(current_waveform:dict[float, float]|None=None,
         voltage_waveform:dict[float, float]|None=None,
         env_conditions:str|None=None, start_time:float|None=None,
-        min_window_duration:float=3, num_cores:int|None=None) \
+        min_window_duration:float=3, num_cores:int|None=None,
+        interpretation:Interpretation=analyzer_support.DEFAULT_INTERPRETATION,
+        standard_version:StandardVersion=
+            analyzer_support.DEFAULT_STANDARD_VERSION) \
         -> tuple[tuple[float, float], ...]:
     """
     Finds the time regions that are below the let-go threshold.  When the
@@ -77,6 +83,10 @@ def find_time_regions_below_letgo(current_waveform:dict[float, float]|None=None,
         size for evaluating data.  For compliance, this should likely be the
         minimum Fault Recovery Period duration required by UL1400-1.
       num_cores: The number of cores to use.  Can be omitted to use all cores.
+      interpretation: The level of how strictly to interpret the standard.  Can
+        be omitted to use default.
+      standard_version: The version of the standard to use for analysis.  Can be
+        omitted to use default.
 
     Returns:
       time_regions_below_letgo [s]: These are the time regions identified as
@@ -130,7 +140,8 @@ def find_time_regions_below_letgo(current_waveform:dict[float, float]|None=None,
                     as progress_bar:
 
                 args = [(measurement_type, waveform, *t, min_window_duration,
-                            env_conditions) for t in target_times]
+                            env_conditions, interpretation, standard_version)
+                            for t in target_times]
                 future_result = pool.starmap_async(_analyze_segment, args,
                         error_callback=_error_handler)
 
@@ -159,7 +170,10 @@ def find_time_regions_below_letgo(current_waveform:dict[float, float]|None=None,
 
 def _analyze_segment(measurement_type:str, waveform:dict[float, float]|None,
         target_start_time:float, target_end_time:float,
-        min_window_duration:float, env_conditions:str|None) \
+        min_window_duration:float, env_conditions:str|None,
+        interpretation:Interpretation=analyzer_support.DEFAULT_INTERPRETATION,
+        standard_version:StandardVersion=
+            analyzer_support.DEFAULT_STANDARD_VERSION) \
         -> tuple[float, float]|None:
     """
     Finds the segment of data to analyze and performs the let-go analysis.
@@ -191,6 +205,10 @@ def _analyze_segment(measurement_type:str, waveform:dict[float, float]|None,
         let-go.  This is only required if the fault voltage waveform is
         provided, as this is the only waveform to which it applies.  The valid
         values are "wet" and "dry".
+      interpretation: The level of how strictly to interpret the standard.  Can
+        be omitted to use default.
+      standard_version: The version of the standard to use for analysis.  Can be
+        omitted to use default.
 
     Returns:
       new_passing_region: The new region, defined as a start and end time, that
@@ -202,7 +220,7 @@ def _analyze_segment(measurement_type:str, waveform:dict[float, float]|None,
             'start')
 
     if is_below_letgo(measurement_type, segment.values(),
-            env_conditions):
+            env_conditions, interpretation, standard_version):
         new_passing_region = (min(segment.keys()), max(segment.keys()))
 
     if _PROGRESS_COUNTER is not None:
@@ -214,7 +232,10 @@ def _analyze_segment(measurement_type:str, waveform:dict[float, float]|None,
 
 
 def is_below_letgo(measurement_type:str, segment_values:list[float]|None,
-        env_conditions:str|None=None) -> bool|None:
+        env_conditions:str|None=None,
+        interpretation:Interpretation=analyzer_support.DEFAULT_INTERPRETATION,
+        standard_version:StandardVersion=
+            analyzer_support.DEFAULT_STANDARD_VERSION) -> bool|None:
     """
     Determines if the provided segment of data is below the let-go threshold.
     When the appropriate data is provided, this can be used to assess if the
@@ -230,6 +251,10 @@ def is_below_letgo(measurement_type:str, segment_values:list[float]|None,
         let-go.  This is only required if the measurement type provided is
         "voltage", as this is the only type to which it applies.  The valid
         values are "wet" and "dry".
+      interpretation: The level of how strictly to interpret the standard.  Can
+        be omitted to use default.
+      standard_version: The version of the standard to use for analysis.  Can be
+        omitted to use default.
 
     Returns:
       _: True if the segment is below the appropriate let-go threshold based on
@@ -242,15 +267,20 @@ def is_below_letgo(measurement_type:str, segment_values:list[float]|None,
         provided.
     """
     if measurement_type == 'current':
-        return is_current_below_letgo(segment_values)
+        return is_current_below_letgo(segment_values, interpretation,
+                standard_version)
     if measurement_type == 'voltage':
-        return is_voltage_below_letgo(segment_values, env_conditions)
+        return is_voltage_below_letgo(segment_values, env_conditions,
+                interpretation, standard_version)
     raise ValueError('Measurement type must be "voltage" or "current", got'
             f' "{measurement_type}"')
 
 
 
-def is_current_below_letgo(segment_values:list[float]|None) -> bool|None:
+def is_current_below_letgo(segment_values:list[float]|None,
+        interpretation:Interpretation=analyzer_support.DEFAULT_INTERPRETATION,
+        standard_version:StandardVersion=
+            analyzer_support.DEFAULT_STANDARD_VERSION) -> bool|None:
     """
     Determines if the provided segment of data is below the let-go threshold for
     current.  When the appropriate data is provided, this can be used to assess
@@ -260,6 +290,10 @@ def is_current_below_letgo(segment_values:list[float]|None) -> bool|None:
       segment_values: The electrical current values of the segment of the
         waveform to evaluate (i.e. times associated with each value are not
         needed and should not be included).
+      interpretation: The level of how strictly to interpret the standard.  Can
+        be omitted to use default.
+      standard_version: The version of the standard to use for analysis.  Can be
+        omitted to use default.
 
     Returns:
       _: True if the segment is below the appropriate let-go threshold based on
@@ -274,33 +308,62 @@ def is_current_below_letgo(segment_values:list[float]|None) -> bool|None:
     if segment_values is None:
         return None
 
+    if standard_version \
+            is not StandardVersion.UL1400_1_ISSUE_1:
+        raise ValueError('Only Standard Version UL1400-1 Issue #1 is supported'
+                ' at this time')
+    if interpretation not in [Interpretation.STRICT, Interpretation.TYPOS,
+            Interpretation.REASONABLE, Interpretation.SPECULATIVE]:
+        raise ValueError(f'Unsupported interpretation: {interpretation}')
+
     a_to_ma_scalar = 1000
 
     peak_ma = max(segment_values) * a_to_ma_scalar
     mean_ma = sum(segment_values) / len(segment_values) * a_to_ma_scalar
 
+    if interpretation in [Interpretation.REASONABLE,
+            Interpretation.SPECULATIVE]:
+        # Based on source of these limits from "Effect of Wave Form on Let-Go
+        #   Currents" by Charles F. Dalziel [December 1943], it could be argued
+        #   that the mean is concerned with the magnitude (i.e. absolute value),
+        #   while the peak is the magnitude (i.e. absolute value) of the largest
+        #   deviation from the zero point.
+        peak_ma = max([abs(x) for x in segment_values]) * a_to_ma_scalar
+        mean_ma = abs(mean_ma)
+
     if mean_ma < 0:
         # This should likely invert or consider worst peak, but technically is
-        #   undefined
+        #   undefined.  See reasonable interpretation for possible handling
         raise ValueError('DC values less than 0 are not supported for let-go:'
                 f' {mean_ma} mA')
+
     if mean_ma <= 4.21:
         limit_ma = 5 * math.sqrt(2)
+
     elif mean_ma <= 30:
-        # NOTE: Technically this is 33.3, not 3.33; but it is easy to determine
-        #   that 33.3 is a typo
-        limit_ma = 3.33 + 0.89 * mean_ma
+        if interpretation is Interpretation.STRICT:
+            limit_ma = 33.3 + 0.89 * mean_ma
+        else:
+            # Via figure 5.4 in UL1400-1 Issue #1, it is easy to confirm that
+            #   33.3 is a typo of 3.33
+            limit_ma = 3.33 + 0.89 * mean_ma
+
     else:
         # This should likely be a failure, but technically is undefined
-        raise ValueError('DC values greater than 30 mA are not supported for'
-                f' let-go: {mean_ma} mA')
+        if interpretation in [Interpretation.STRICT, Interpretation.TYPOS]:
+            raise ValueError('DC values greater than 30 mA are not supported'
+                    f' for let-go: {mean_ma} mA')
+        return False
 
     return peak_ma <= limit_ma
 
 
 
 def is_voltage_below_letgo(segment_values:list[float]|None,
-        env_conditions:str) -> bool|None:
+        env_conditions:str,
+        interpretation:Interpretation=analyzer_support.DEFAULT_INTERPRETATION,
+        standard_version:StandardVersion=
+            analyzer_support.DEFAULT_STANDARD_VERSION) -> bool|None:
     """
     Determines if the provided segment of data is below the let-go threshold for
     voltage.  When the appropriate data is provided, this can be used to assess
@@ -314,6 +377,10 @@ def is_voltage_below_letgo(segment_values:list[float]|None,
         let-go.  This is only required if the measurement type provided is
         "voltage", as this is the only type to which it applies.  The valid
         values are "wet" and "dry".
+      interpretation: The level of how strictly to interpret the standard.  Can
+        be omitted to use default.
+      standard_version: The version of the standard to use for analysis.  Can be
+        omitted to use default.
 
     Returns:
       _: True if the segment is below the appropriate let-go threshold based on
@@ -329,12 +396,30 @@ def is_voltage_below_letgo(segment_values:list[float]|None,
     if segment_values is None:
         return None
 
+    if standard_version \
+            is not StandardVersion.UL1400_1_ISSUE_1:
+        raise ValueError('Only Standard Version UL1400-1 Issue #1 is supported'
+                ' at this time')
+    if interpretation not in [Interpretation.STRICT, Interpretation.TYPOS,
+            Interpretation.REASONABLE, Interpretation.SPECULATIVE]:
+        raise ValueError(f'Unsupported interpretation: {interpretation}')
+
     if env_conditions not in ['wet', 'dry']:
         raise ValueError('Environmental conditions must be specified as wet or'
                 f' dry; got {env_conditions}')
 
     peak = max(segment_values)
     mean = sum(segment_values) / len(segment_values)
+
+    if interpretation in [Interpretation.REASONABLE,
+            Interpretation.SPECULATIVE]:
+        # Based on source of these limits from "Effect of Wave Form on Let-Go
+        #   Currents" by Charles F. Dalziel [December 1943], it could be argued
+        #   that the mean is concerned with the magnitude (i.e. absolute value),
+        #   while the peak is the magnitude (i.e. absolute value) of the largest
+        #   deviation from the zero point.
+        peak = max([abs(x) for x in segment_values])
+        mean = abs(mean)
 
     if mean < 0:
         # This should likely invert or consider worst peak, but technically is
@@ -349,8 +434,11 @@ def is_voltage_below_letgo(segment_values:list[float]|None,
             limit = 16.5 + 0.45 * mean
         else:
             # This should likely be a failure, but technically is undefined
-            raise ValueError('DC values greater than 30 V are not supported for'
-                    f' let-go under wet conditions: {mean} V')
+            if interpretation in [Interpretation.STRICT, Interpretation.TYPOS]:
+                raise ValueError('DC values greater than 30 V are not supported'
+                        f' for let-go under wet conditions: {mean} V')
+            return False
+
     elif env_conditions == 'dry':
         if mean <= 20.9:
             limit = 42.4
@@ -358,7 +446,9 @@ def is_voltage_below_letgo(segment_values:list[float]|None,
             limit = 33 + 0.45 * mean
         else:
             # This should likely be a failure, but technically is undefined
-            raise ValueError('DC values greater than 60 V are not supported for'
-                    f' let-go under dry conditions: {mean} V')
+            if interpretation in [Interpretation.STRICT, Interpretation.TYPOS]:
+                raise ValueError('DC values greater than 60 V are not supported'
+                        f' for let-go under dry conditions: {mean} V')
+            return False
 
     return peak <= limit

--- a/ul1400_1_analyzer/analysis/letgo_analyzer.py
+++ b/ul1400_1_analyzer/analysis/letgo_analyzer.py
@@ -366,7 +366,7 @@ def is_current_below_letgo(segment_values:list[float]|None,
         #   that the mean is concerned with the magnitude (i.e. absolute value),
         #   while the peak is the magnitude (i.e. absolute value) of the largest
         #   deviation from the zero point.
-        peak_ma = max([abs(x) for x in segment_values]) * a_to_ma_scalar
+        peak_ma = max(abs(x) for x in segment_values) * a_to_ma_scalar
         mean_ma = abs(mean_ma)
 
     if mean_ma < 0:
@@ -458,7 +458,7 @@ def is_voltage_below_letgo(segment_values:list[float]|None,
         #   that the mean is concerned with the magnitude (i.e. absolute value),
         #   while the peak is the magnitude (i.e. absolute value) of the largest
         #   deviation from the zero point.
-        peak = max([abs(x) for x in segment_values])
+        peak = max(abs(x) for x in segment_values)
         mean = abs(mean)
 
     if mean < 0:

--- a/ul1400_1_analyzer/analysis/letgo_analyzer.py
+++ b/ul1400_1_analyzer/analysis/letgo_analyzer.py
@@ -42,6 +42,43 @@ def _init_shared_data(shared_data:Any) -> None:
 
 
 
+def audit_config_valid(interpretation:Interpretation|None,
+        standard_version:StandardVersion, min_window_duration:float|None=None,
+        **_kwargs:Any) -> None:
+    """
+    Audits the configuration parameters to confirm they are valid to critically
+    assess to the standard.
+
+    Will provide a warning message if there is a possibility that results could
+    mislead towards a false positive on compliance.
+
+    Args:
+      interpretation: The level of how strictly to interpret the standard.
+      standard_version: The version of the standard to use for analysis.
+      min_window_duration [s]: The minimum time duration to use as a window
+        size for evaluating data.  For compliance, this should likely be the
+        minimum Fault Recovery Period duration required by UL1400-1.
+      **_kwargs: Absorbs any extra keywords arguments that may be passed in.
+        Not used.
+
+    Raises:
+      ValueError: Raised if an unsupported interpretation or standard version
+        was provided.
+    """
+    if standard_version \
+            is not StandardVersion.UL1400_1_ISSUE_1:
+        raise ValueError('Only Standard Version UL1400-1 Issue #1 is supported'
+                ' at this time')
+    if interpretation not in [Interpretation.STRICT, Interpretation.TYPOS,
+            Interpretation.REASONABLE, Interpretation.SPECULATIVE]:
+        raise ValueError(f'Unsupported interpretation: {interpretation}')
+
+    if min_window_duration < 3:
+        print('**WARNING** Window duration is too small to correctly assess the'
+                ' Fault Recovery Period for UL1400-1 Issue #1')
+
+
+
 def find_time_regions_below_letgo(current_waveform:dict[float, float]|None=None,
         voltage_waveform:dict[float, float]|None=None,
         env_conditions:str|None=None, start_time:float|None=None,

--- a/ul1400_1_analyzer/main.py
+++ b/ul1400_1_analyzer/main.py
@@ -105,6 +105,8 @@ def main_letgo(format_type:str, importer_type:str,
             print(f' {index + 1}: {region[0]*1000:.3f} ms'
                     f' - {region[1]*1000:.3f} ms')
 
+    letgo_analyzer.audit_config_valid(**analyzer_kwargs)
+
 
 
 

--- a/ul1400_1_analyzer/main.py
+++ b/ul1400_1_analyzer/main.py
@@ -51,7 +51,10 @@ def main_letgo(format_type:str, importer_type:str,
         let-go.  This is only required if the fault voltage waveform is
         provided, as this is the only waveform to which it applies.  The valid
         values are "wet" and "dry".
-      start_time [s]:
+      start_time [s]: The time above which to analyze waveform data.  This is
+        useful if the fault is introduced at some mid-point in the time series
+        and may contain invalid data earlier than that.  This can be omitted to
+        use all data in the waveforms.
       voltage_waveform_id: The identifier for the voltage waveform in the data
         being imported.  Usage depends on the importer and format type.  Can be
         omitted if voltage waveform is not being analyzed.

--- a/ul1400_1_analyzer/utils/__init__.py
+++ b/ul1400_1_analyzer/utils/__init__.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
+    'cli',
     'waveform',
 ]

--- a/ul1400_1_analyzer/utils/cli.py
+++ b/ul1400_1_analyzer/utils/cli.py
@@ -1,0 +1,125 @@
+"""
+Includes support for Command Line Interface tools.
+
+Module Attributes:
+  N/A
+"""
+import argparse
+from enum import Enum
+from typing import Any
+
+
+
+class CaseInsensitiveChoices(list):
+    """
+    A helper class for "choice" options when adding arguments for argparse
+    parsers, this facilitates comparing choice options in a case-insensitive
+    fashion while not losing the case information of the user's input.
+
+    This does require the expected choice options to be upper-case.
+    """
+    def __contains__(self, other:object) -> bool:
+        """
+        Checks if the other element (regardless of case) is contained in this
+        list.
+
+        Args:
+          other: The item to check if it is contained in this list.
+
+        Returns:
+          _: True if item is contained in the list, regardless of case; False
+            otherwise.
+
+        Raises:
+          TypeError: Raised if a non-string item is passed in as the other
+            element to check if it is contained in this list.
+        """
+        if not isinstance(other, str):
+            raise TypeError('Only string types supported')
+        return super().__contains__(other.upper())
+
+
+
+class EnumByNameAction(argparse.Action):
+    """
+    A helper class for the "action" to take when adding arguments to argparse
+    parsers, this allows CLI input to be compared against enum member names in
+    a case-insensitive fashion while still supporting the display of choices if
+    an invalid input is entered (or help is requested).
+
+    This does force the display of choice options to be the enum member names in
+    upper case.
+
+    Instance Attributes:
+      _enum_type: The Enum that was defined as the type by the argparse parser
+        option.
+    """
+    def __init__(self, option_strings:Any, dest:Any, nargs:Any=None,
+            **kwargs:Any) -> None:
+        """
+        Creates the action, ensuring that the proper inputs have been provided
+        by the argparse parser.
+
+        Args:
+          option_strings: The option strings allowed for this argument.  Not
+            relevant for positional arguments.
+          dest: The destination variable name.
+          nargs: The number of args configuration for the parser argument.  This
+            is expected to be None (i.e. omitted when adding the argument).
+          **kwargs: The other keyword arguments.  It is required that 'type` be
+            one of the keys, where the value is expected to be an Enum subclass.
+
+        Raises:
+          TypeError: Raised if no 'type' is provided.
+          ValueError: Raised if nargs used (which is not supported), or the
+            'type' is defined as a non-Enum class.
+        """
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+
+        enum_type = kwargs.pop('type', None)
+        if enum_type is None:
+            raise ValueError('`type` must be provided to argument kwargs')
+        if not issubclass(enum_type, Enum):
+            raise TypeError('Only enum types supported')
+
+        kwargs.setdefault('choices', CaseInsensitiveChoices(
+                [e.name.upper() for e in enum_type]))
+
+        super().__init__(option_strings, dest, **kwargs)
+
+        self._enum_type = enum_type
+
+
+
+    def __call__(self, parser:argparse.ArgumentParser,
+            namespace:argparse.Namespace, values:Any,
+            option_string:str|None=None) -> None:
+        """
+        Parses the command line string received for this argument option.  With
+        a valid string passed to `values`, this will set the destination
+        variable to the parsed enum member.
+
+        Args:
+          parser: The ArgumentParser object which contains this action.
+          namespace: The Namespace object that will be returned by parse_args().
+            Most actions add an attribute to this object using setattr().
+          values: The associated command-line arguments, with any type
+            conversions applied.  Type conversions are specified with the type
+            keyword argument to add_argument().
+          option_string: The option string that was used to invoke this action.
+            The option_string argument is optional, and will be absent if the
+            action is associated with a positional argument.
+
+        Raises:
+          ValueError: Raised if the values received cannot be parsed as a valid
+            enum member.
+        """
+        value = None
+        for member in self._enum_type:
+            if values.upper() == member.name.upper():
+                value = member
+        if value is None:
+            raise ValueError(f'Invalid value for {self._enum_type.__name__}'
+                    f' enum: {values}')
+        setattr(namespace, self.dest, value)


### PR DESCRIPTION
This adds support for specifying the version of the standard to use for the assessment, as well as the "interpretation level", where that interpretation level can range from a strict reading of the standard to a more speculative interpretation that attempts to resolve ambiguous, conflicting, or absent material.

Closes #5.  Closes #6.